### PR TITLE
Use correct size to prevent buffer overflow

### DIFF
--- a/src/LmiBmc.c
+++ b/src/LmiBmc.c
@@ -456,7 +456,7 @@ int populate_bmc_info_with_ipmi(BMC_info *bmc_info)
     }
     bmc_info->supportedProtoVersions[0] =tmp_str;
 
-    tmp_str = calloc(4, sizeof(char));
+    tmp_str = calloc(5, sizeof(char));
     if (tmp_str == NULL)
     {
 	lmi_error ("Failed while allocating memory");


### PR DESCRIPTION
I suppose we need a size of 5 here, since you want to copy "IPMI" in
that buffer later on.
